### PR TITLE
修改 AUR 地址以适配软件名的更改

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -33,7 +33,8 @@ English | [简体中文](./README.md)
 - [Gitee Releases](https://gitee.com/rmbgame/SteamTools/releases)
 - [Official WebSite](https://steampp.net)
 - [![Microsoft Store](./resources/MSStore_English.png)](https://www.microsoft.com/store/apps/9MTCFHS560NG)
-- [Arch Linux Package](https://aur.archlinux.org/packages/steam%2B%2B-bin)(By [zhanghua000](https://github.com/zhanghua000))
+- [AUR](https://aur.archlinux.org/packages/watt-toolkit-bin)(Official Release)
+- [AUR dev](https://aur.archlinux.org/packages/watt-toolkit-git)(Pull latest code and build locally, build maybe failed, also don't guarantee availability)
 
 ## ✨ Functions
 1. Network Acceleration <img src="./resources/windows-brands.svg" width="16" height="16" /> <img src="./resources/linux-brands.svg" width="16" height="16" /> <img src="./resources/apple-brands.svg" width="16" height="16" /> <img src="./resources/android-brands.svg" width="16" height="16" /> 
@@ -85,7 +86,7 @@ OS                                    | Version               | Architectures   
 [SUSE Enterprise Linux (SLES)][SLES]  | 12 SP2+               | x64               | [SUSE][SLES-lifecycle]
 [Ubuntu][Ubuntu]                      | 16.04, 18.04, 20.04+  | x64, Arm64        | [Ubuntu][Ubuntu-lifecycle]
 [Deepin / UOS][Deepin]                | 20+                   | x64               | [Deepin][Deepin-lifecycle]
-[Arch Linux][Arch]                    |                       | x64               | 
+[Arch Linux][Arch]                    |                       | x64, Arm64        | 
 
 [Alpine]: https://alpinelinux.org/
 [Alpine-lifecycle]: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 - [Gitee Releases](https://gitee.com/rmbgame/SteamTools/releases)
 - [Official WebSite](https://steampp.net)
 - [![Microsoft Store](./resources/MSStore_English.png)](https://www.microsoft.com/store/apps/9MTCFHS560NG)
-- [Arch Linux Package](https://aur.archlinux.org/packages/steam%2B%2B-bin)(By [zhanghua000](https://github.com/zhanghua000))
+- [AUR](https://aur.archlinux.org/packages/watt-toolkit-bin)(官方 Release 构建)
+- [AUR dev](https://aur.archlinux.org/packages/watt-toolkit-git)(拉取最新源代码从本地构建，不保证可用性，构建也许会出现失败问题)
 
 ## ✨ 功能
 1. 网络加速 <img src="./resources/windows-brands.svg" width="16" height="16" /> <img src="./resources/linux-brands.svg" width="16" height="16" /> <img src="./resources/apple-brands.svg" width="16" height="16" /> <img src="./resources/android-brands.svg" width="16" height="16" /> 
@@ -87,7 +88,7 @@ OS                                    | Version               | Architectures   
 [SUSE Enterprise Linux (SLES)][SLES]  | 12 SP2+               | x64               | [SUSE][SLES-lifecycle]
 [Ubuntu][Ubuntu]                      | 16.04, 18.04, 20.04+  | x64, Arm64        | [Ubuntu][Ubuntu-lifecycle]
 [Deepin / UOS][Deepin]                | 20+                   | x64               | [Deepin][Deepin-lifecycle]
-[Arch Linux][Arch]                    |                       | x64               | 
+[Arch Linux][Arch]                    |                       | x64，Arm64        | 
 
 [Alpine]: https://alpinelinux.org/
 [Alpine-lifecycle]: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases


### PR DESCRIPTION
1. 添加了一个以 -git 结尾的开发类型的软件包，用于直接从源代码构建
2. 为 Arch 的软件架构列表中添加 Arm64(aarch64) 架构，这个架构由 [ArchLinuxARM](https://archlinuxarm.org/) 这个非官方项目提供支持