### PR TITLE
Add Firewall Rules to AppxManifest

### DIFF
--- a/src/ST.Client.Desktop.Avalonia.App.Bridge.Package/Package.appxmanifest
+++ b/src/ST.Client.Desktop.Avalonia.App.Bridge.Package/Package.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
-  IgnorableNamespaces="uap rescap">
+  xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
+  IgnorableNamespaces="uap rescap desktop desktop2">
 
   <Identity
     Name="4651ED44255E.47979655102CE"
@@ -58,6 +59,15 @@
       </Extensions>
     </Application>
   </Applications>
+
+  <Extensions>
+    <desktop2:Extension Category="windows.firewallRules">
+      <desktop2:FirewallRules Executable="Steam++\Steam++.exe">
+        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all" />
+        <desktop2:Rule Direction="in" IPProtocol="UDP" Profile="all" />
+      </desktop2:FirewallRules>
+    </desktop2:Extension>
+  </Extensions>
 
   <Capabilities>
     <Capability Name="internetClient" />

--- a/src/ST.Client.Desktop.Avalonia.App.Bridge2/Package.appxmanifest
+++ b/src/ST.Client.Desktop.Avalonia.App.Bridge2/Package.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
-  IgnorableNamespaces="uap rescap">
+  xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
+  IgnorableNamespaces="uap rescap desktop desktop2">
 
   <Identity
     Name="4651ED44255E.47979655102CE"
@@ -58,6 +59,15 @@
       </Extensions>
     </Application>
   </Applications>
+
+  <Extensions>
+    <desktop2:Extension Category="windows.firewallRules">
+      <desktop2:FirewallRules Executable="Steam++\Steam++.exe">
+        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all" />
+        <desktop2:Rule Direction="in" IPProtocol="UDP" Profile="all" />
+      </desktop2:FirewallRules>
+    </desktop2:Extension>
+  </Extensions>
 
   <Capabilities>
     <Capability Name="internetClient" />


### PR DESCRIPTION
Everytime app(packaging by appx/msix) updating, installation path will be changed. So the dialog of Firewall will appear after ms-store updating app. According to Microsoft docs, the rules should be added into `AppxManifest.xml`.

![Screenshot 2022-07-24 205437](https://user-images.githubusercontent.com/57533055/180655606-06bf062b-84a8-4b3e-b7bb-58727ecb0860.png)

Thanks a lot.
