### PR TITLE
🐛 初次启动时"设置页面-启动页设置项"显示修复

### DIFF
--- a/src/BD.WTTS.Client/UI/ViewModels/Pages/SettingsPageViewModel.props.cs
+++ b/src/BD.WTTS.Client/UI/ViewModels/Pages/SettingsPageViewModel.props.cs
@@ -39,7 +39,7 @@ public sealed partial class SettingsPageViewModel : TabItemViewModel
             {
                 if (string.IsNullOrEmpty(UISettings.StartDefaultPageName.Value))
                 {
-                    return s.Id == "Welcome";
+                    return s.Id == "Watt Toolkit-Welcome";
                 }
                 return s.Id == UISettings.StartDefaultPageName.Value;
             });


### PR DESCRIPTION
![bug1](https://github.com/user-attachments/assets/ec15ac27-a24c-4376-baed-2e71b693b01f)
如图，首次启动时，“启动时默认打开页面” 显示空白