### PR TITLE
🐛 修复启用 “启动时自动加速” 后，测试页面不显示问题

### DIFF
--- a/src/BD.WTTS.Client.Plugins.Accelerator/Services/Mvvm/ProxyService.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/Services/Mvvm/ProxyService.cs
@@ -114,8 +114,6 @@ public sealed partial class ProxyService
 
     public SourceList<ScriptDTO> ProxyScripts { get; }
 
-    public event EventHandler<bool>? OnStartOrStopProxyService;
-
     public async Task StartOrStopProxyService(bool startOrStop)
     {
         if (startOrStop == ProxyStatus)
@@ -155,7 +153,6 @@ public sealed partial class ProxyService
             ProxyStarting = false;
             ProxyStatus = startOrStop;
             IsAnyProxyScripts = ProxyStatus && IsEnableScript;
-            OnStartOrStopProxyService?.Invoke(this, startOrStop);
         }
     }
 

--- a/src/BD.WTTS.Client.Plugins.Accelerator/Services/Mvvm/ProxyService.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/Services/Mvvm/ProxyService.cs
@@ -114,6 +114,8 @@ public sealed partial class ProxyService
 
     public SourceList<ScriptDTO> ProxyScripts { get; }
 
+    public event EventHandler<bool>? OnStartOrStopProxyService;
+
     public async Task StartOrStopProxyService(bool startOrStop)
     {
         if (startOrStop == ProxyStatus)
@@ -153,6 +155,7 @@ public sealed partial class ProxyService
             ProxyStarting = false;
             ProxyStatus = startOrStop;
             IsAnyProxyScripts = ProxyStatus && IsEnableScript;
+            OnStartOrStopProxyService?.Invoke(this, startOrStop);
         }
     }
 

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.cs
@@ -20,7 +20,10 @@ public sealed partial class AcceleratorPageViewModel
         ProxyService.Current.OnStartOrStopProxyService += (_, start) =>
         {
             if (start == false)
+            {
+                EnableProxyDomainGroupVMs = null;
                 return;
+            }
 
             // Create new ProxyEnableDomain for 加速服务 page
             var enableGroupDomain = ProxyService.Current.ProxyDomainsList
@@ -113,8 +116,11 @@ public sealed partial class AcceleratorPageViewModel
                     var configDns = ProxySettings.ProxyMasterDns.Value ?? string.Empty;
                     (delayMs, address) = await networkTestService.TestDNSAsync(testDomain, configDns, 53);
                 }
+                if (address.Length == 0)
+                    throw new Exception("Parsing failed. Return empty ip address.");
+
                 DNSTestDelay = delayMs + "ms ";
-                DNSTestResult = "" + address.FirstOrDefault() ?? "0.0.0.0";
+                DNSTestResult = string.Empty + address.FirstOrDefault();
             }
             catch (Exception ex)
             {

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.cs
@@ -17,15 +17,9 @@ public sealed partial class AcceleratorPageViewModel
 
     public AcceleratorPageViewModel()
     {
-        StartProxyCommand = ReactiveCommand.CreateFromTask(async _ =>
+        ProxyService.Current.OnStartOrStopProxyService += (_, start) =>
         {
-#if LINUX
-            if (!EnvironmentCheck()) return;
-#endif
-            //ProxyService.Current.ProxyStatus = !ProxyService.Current.ProxyStatus;
-            await ProxyService.Current.StartOrStopProxyService(!ProxyService.Current.ProxyStatus);
-
-            if (ProxyService.Current.ProxyStatus == false)
+            if (start == false)
                 return;
 
             // Create new ProxyEnableDomain for 加速服务 page
@@ -47,6 +41,15 @@ public sealed partial class AcceleratorPageViewModel
                 .ToList();
 
             EnableProxyDomainGroupVMs = enableGroupDomain.AsReadOnly();
+        };
+
+        StartProxyCommand = ReactiveCommand.CreateFromTask(async _ =>
+        {
+#if LINUX
+            if (!EnvironmentCheck()) return;
+#endif
+            //ProxyService.Current.ProxyStatus = !ProxyService.Current.ProxyStatus;
+            await ProxyService.Current.StartOrStopProxyService(!ProxyService.Current.ProxyStatus);
         });
 
         RefreshCommand = ReactiveCommand.Create(async () =>


### PR DESCRIPTION
在 ProxyService 中添加事件通知，加速服务启动后，通知到vm更新测试页面的页面数据