### PR TITLE
💄 网络测试子页面重构

### DIFF
--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.props.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.props.cs
@@ -4,12 +4,13 @@ namespace BD.WTTS.UI.ViewModels;
 
 public sealed partial class AcceleratorPageViewModel : TabItemViewModel
 {
-    public enum NatTypeSimple
+    public record NATFetchResult(string PublicEndPoint, string LocalEndPoint, string NATLevel, string NATTypeTip, bool PingResult);
+
+    public enum PingStatus
     {
-        Unknown,
-        Open,
-        Moderate,
-        Strict,
+        Blank,
+        Ok,
+        Error,
     }
 
     public override string Name => Strings.Welcome;
@@ -24,6 +25,21 @@ public sealed partial class AcceleratorPageViewModel : TabItemViewModel
         "stun.fitauto.ru",
         "stun.miwifi.com",
     ];
+
+    [ObservableAsProperty]
+    public string NATLevel { get; } = string.Empty;
+
+    [ObservableAsProperty]
+    public string NATTypeTip { get; } = string.Empty;
+
+    [ObservableAsProperty]
+    public string LocalEndPoint { get; set; } = string.Empty;
+
+    [ObservableAsProperty]
+    public string PublicEndPoint { get; set; } = string.Empty;
+
+    [ObservableAsProperty]
+    public PingStatus PingResultStatus { get; }
 
     [ObservableAsProperty]
     public bool IsNATChecking { get; }
@@ -41,12 +57,6 @@ public sealed partial class AcceleratorPageViewModel : TabItemViewModel
     public ReadOnlyCollection<ProxyDomainGroupViewModel>? EnableProxyDomainGroupVMs { get; set; }
 
     [Reactive]
-    public string LocalEndPoint { get; set; } = string.Empty;
-
-    [Reactive]
-    public string PublicEndPoint { get; set; } = string.Empty;
-
-    [Reactive]
     public string DNSTestDelay { get; set; } = string.Empty;
 
     [Reactive]
@@ -58,7 +68,7 @@ public sealed partial class AcceleratorPageViewModel : TabItemViewModel
     [Reactive]
     public bool IsSupportIPv6 { get; set; }
 
-    public ReactiveCommand<Unit, (NatTypeSimple Nat, bool PingSuccess)> NATCheckCommand { get; }
+    public ReactiveCommand<Unit, NATFetchResult> NATCheckCommand { get; }
 
     public ReactiveCommand<Unit, Unit> DNSCheckCommand { get; }
 

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.props.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/AcceleratorPageViewModel.props.cs
@@ -4,75 +4,10 @@ namespace BD.WTTS.UI.ViewModels;
 
 public sealed partial class AcceleratorPageViewModel : TabItemViewModel
 {
-    public record NATFetchResult(string PublicEndPoint, string LocalEndPoint, string NATLevel, string NATTypeTip, bool PingResult);
-
-    public enum PingStatus
-    {
-        Blank,
-        Ok,
-        Error,
-    }
-
     public override string Name => Strings.Welcome;
 
     [Reactive]
-    public string SelectedSTUNAddress { get; set; }
-
-    public string[] STUNAddress { get; } =
-    [
-        "stun.syncthing.net",
-        "stun.hot-chilli.net",
-        "stun.fitauto.ru",
-        "stun.miwifi.com",
-    ];
-
-    [ObservableAsProperty]
-    public string NATLevel { get; } = string.Empty;
-
-    [ObservableAsProperty]
-    public string NATTypeTip { get; } = string.Empty;
-
-    [ObservableAsProperty]
-    public string LocalEndPoint { get; set; } = string.Empty;
-
-    [ObservableAsProperty]
-    public string PublicEndPoint { get; set; } = string.Empty;
-
-    [ObservableAsProperty]
-    public PingStatus PingResultStatus { get; }
-
-    [ObservableAsProperty]
-    public bool IsNATChecking { get; }
-
-    [ObservableAsProperty]
-    public bool IsDNSChecking { get; }
-
-    [ObservableAsProperty]
-    public bool IsIPv6Checking { get; }
-
-    [Reactive]
-    public string DomainPendingTest { get; set; } = string.Empty;
-
-    [Reactive]
     public ReadOnlyCollection<ProxyDomainGroupViewModel>? EnableProxyDomainGroupVMs { get; set; }
-
-    [Reactive]
-    public string DNSTestDelay { get; set; } = string.Empty;
-
-    [Reactive]
-    public string DNSTestResult { get; set; } = string.Empty;
-
-    [Reactive]
-    public string IPv6Address { get; set; } = string.Empty;
-
-    [Reactive]
-    public bool IsSupportIPv6 { get; set; }
-
-    public ReactiveCommand<Unit, NATFetchResult> NATCheckCommand { get; }
-
-    public ReactiveCommand<Unit, Unit> DNSCheckCommand { get; }
-
-    public ReactiveCommand<Unit, Unit> IPv6CheckCommand { get; }
 
     public ICommand StartProxyCommand { get; }
 

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/NetworkCheckControlViewModel.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/ViewModels/NetworkCheckControlViewModel.cs
@@ -1,0 +1,183 @@
+using STUN.Enums;
+using STUN.StunResult;
+using System.Reactive;
+
+namespace BD.WTTS.UI.ViewModels;
+
+public class NetworkCheckControlViewModel : ViewModelBase
+{
+    private readonly INetworkTestService _networkTestService = INetworkTestService.Instance;
+
+    public record NATFetchResult(string PublicEndPoint, string LocalEndPoint, string NATLevel, string NATTypeTip, bool PingResult);
+
+    [Reactive]
+    public string SelectedSTUNAddress { get; set; }
+
+    public string[] STUNAddress { get; } =
+    [
+        "stun.syncthing.net",
+        "stun.hot-chilli.net",
+        "stun.fitauto.ru",
+        "stun.miwifi.com",
+    ];
+
+    [ObservableAsProperty]
+    public string NATLevel { get; } = string.Empty;
+
+    [ObservableAsProperty]
+    public string NATTypeTip { get; } = string.Empty;
+
+    [ObservableAsProperty]
+    public string LocalEndPoint { get; } = string.Empty;
+
+    [ObservableAsProperty]
+    public string PublicEndPoint { get; } = string.Empty;
+
+    [ObservableAsProperty]
+    public bool PingOkVisible { get; }
+
+    [ObservableAsProperty]
+    public bool PingErrorVisible { get; }
+
+    [ObservableAsProperty]
+    public bool IsNATChecking { get; }
+
+    [ObservableAsProperty]
+    public bool IsDNSChecking { get; }
+
+    [ObservableAsProperty]
+    public bool IsIPv6Checking { get; }
+
+    [Reactive]
+    public string DomainPendingTest { get; set; } = string.Empty;
+
+    [Reactive]
+    public string DNSTestDelay { get; set; } = string.Empty;
+
+    [Reactive]
+    public string DNSTestResult { get; set; } = string.Empty;
+
+    [Reactive]
+    public string IPv6Address { get; set; } = string.Empty;
+
+    [Reactive]
+    public bool IsSupportIPv6 { get; set; }
+
+    public ReactiveCommand<Unit, NATFetchResult> NATCheckCommand { get; }
+
+    public ReactiveCommand<Unit, Unit> DNSCheckCommand { get; }
+
+    public ReactiveCommand<Unit, Unit> IPv6CheckCommand { get; }
+
+    public NetworkCheckControlViewModel()
+    {
+        SelectedSTUNAddress = STUNAddress[0];
+
+        NATCheckCommand = ReactiveCommand.CreateFromTask(async () =>
+        {
+            var natCheckResult = await _networkTestService.TestStunClient3489Async(testServerHostName: SelectedSTUNAddress) ?? new ClassicStunResult { NatType = NatType.Unknown };
+            var (netSucc, _) = await _networkTestService.TestOpenUrlAsync("https://www.baidu.com");
+
+            var publicEndPoint = natCheckResult.PublicEndPoint?.Address.ToString() ?? "Unknown";
+            var localEndPoint = natCheckResult.LocalEndPoint?.Address.ToString() ?? "Unknown";
+
+            var (natLevel, natTypeTip) = natCheckResult.NatType switch
+            {
+                // Open
+                NatType.OpenInternet or NatType.FullCone => ("开放 NAT", "您可与在其网络上具有任意 NAT 类型的用户玩多人游戏和发起多人游戏。"),
+                // Moderate
+                NatType.RestrictedCone or NatType.PortRestrictedCone or NatType.SymmetricUdpFirewall => ("中等 NAT", "您可与一些用户玩多人游戏；但是，并且通常你将不会被选为比赛的主持人。"),
+                // Strict
+                NatType.Symmetric or NatType.UdpBlocked => ("严格 NAT", "您只能与具有开放 NAT 类型的用户玩多人游戏。您不能被选为比赛的主持人。"),
+                // Unknown
+                NatType.Unknown or NatType.UnsupportedServer or _ => ("不可用 NAT", "如果 NAT 不可用，您将无法使用群聊天或连接到某些 Xbox 游戏的多人游戏。"),
+            };
+
+            return new NATFetchResult(publicEndPoint, localEndPoint, natLevel, natTypeTip, netSucc);
+        });
+        NATCheckCommand
+            .IsExecuting
+            .ToPropertyEx(this, x => x.IsNATChecking);
+        NATCheckCommand
+            .Select(x => x.PublicEndPoint)
+            .ToPropertyEx(this, x => x.PublicEndPoint);
+        NATCheckCommand
+            .Select(x => x.LocalEndPoint)
+            .ToPropertyEx(this, x => x.LocalEndPoint);
+        NATCheckCommand
+            .Select(x => x.NATLevel)
+            .Merge(Observable.Return("未知"))
+            .ToPropertyEx(this, x => x.NATLevel);
+        NATCheckCommand
+            .Select(x => x.NATTypeTip)
+            .Merge(Observable.Return("未知类型"))
+            .ToPropertyEx(this, x => x.NATTypeTip);
+
+        var hidePingResultStream = NATCheckCommand
+            .IsExecuting
+            .Where(x => x == true)
+            .Select(x => false);
+        NATCheckCommand
+            .Select(x => x.PingResult == true)
+            .Merge(hidePingResultStream)
+            .ToPropertyEx(this, x => x.PingOkVisible);
+        NATCheckCommand
+            .Select(x => x.PingResult == false)
+            .Merge(hidePingResultStream)
+            .ToPropertyEx(this, x => x.PingErrorVisible);
+
+        DNSCheckCommand = ReactiveCommand.CreateFromTask(async () =>
+        {
+            var testDomain = DomainPendingTest == string.Empty ? "store.steampowered.com" : DomainPendingTest;
+            try
+            {
+                long delayMs;
+                IPAddress[] address;
+                if (ProxySettings.UseDoh)
+                {
+                    var configDoh = ProxySettings.CustomDohAddres2.Value ?? ProxySettingsWindowViewModel.DohAddress.FirstOrDefault() ?? string.Empty;
+                    (delayMs, address) = await _networkTestService.TestDNSOverHttpsAsync(testDomain, configDoh);
+                }
+                else
+                {
+                    var configDns = ProxySettings.ProxyMasterDns.Value ?? string.Empty;
+                    (delayMs, address) = await _networkTestService.TestDNSAsync(testDomain, configDns, 53);
+                }
+                if (address.Length == 0)
+                    throw new Exception("Parsing failed. Return empty ip address.");
+
+                DNSTestDelay = delayMs + "ms ";
+                DNSTestResult = string.Empty + address.FirstOrDefault();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(nameof(AcceleratorPageViewModel), ex.ToString());
+                DNSTestDelay = string.Empty;
+                DNSTestResult = "error";
+            }
+        });
+        DNSCheckCommand
+            .IsExecuting
+            .ToPropertyEx(this, x => x.IsDNSChecking);
+
+        IPv6CheckCommand = ReactiveCommand.CreateFromTask(async () =>
+        {
+            var result = await IMicroServiceClient.Instance.Accelerate.GetMyIP(ipV6: true);
+            if (result.IsSuccess)
+            {
+                IsSupportIPv6 = true;
+                IPv6Address = result.Content ?? string.Empty;
+            }
+            else
+            {
+                IsSupportIPv6 = false;
+                IPv6Address = string.Empty;
+            }
+        });
+        IPv6CheckCommand
+            .IsExecuting
+            .ToPropertyEx(this, x => x.IsIPv6Checking);
+
+        IPv6CheckCommand.Execute().Subscribe();
+    }
+}

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Controls/NetworkCheck.axaml
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Controls/NetworkCheck.axaml
@@ -11,7 +11,7 @@
     xmlns:ui="using:FluentAvalonia.UI.Controls"
     d:DesignHeight="450"
     d:DesignWidth="800"
-    x:DataType="spp:AcceleratorPageViewModel"
+    x:DataType="spp:NetworkCheckControlViewModel"
     mc:Ignorable="d">
     <ScrollViewer
         Padding="0,0,10,0"
@@ -42,7 +42,6 @@
                             x:Name="NATCheckButton"
                             Width="100"
                             Margin="0,0,0,4"
-                            x:FieldModifier="public"
                             Command="{Binding NATCheckCommand}"
                             Content="检测"
                             IsEnabled="True" />
@@ -63,14 +62,14 @@
                                     x:Name="NATTextBlock"
                                     VerticalAlignment="Center"
                                     Foreground="Gray"
-                                    Text="未知" />
+                                    Text="{Binding NATLevel}" />
                                 <ui:FontIcon
                                     Margin="3,0"
                                     FontSize="20"
                                     Glyph="&#xE946;"
                                     ToolTip.ShowDelay="0">
                                     <ToolTip.Tip>
-                                        <TextBlock x:Name="NATTypeTip" Text="未知类型" />
+                                        <TextBlock x:Name="NATTypeTip" Text="{Binding NATTypeTip}" />
                                     </ToolTip.Tip>
                                 </ui:FontIcon>
                             </DockPanel>
@@ -126,13 +125,13 @@
                             <ui:FontIcon
                                 x:Name="PingOK"
                                 HorizontalAlignment="Right"
-                                x:FieldModifier="public"
                                 FontFamily="{StaticResource SymbolThemeFontFamily}"
                                 FontSize="26"
                                 Foreground="Green"
-                                Glyph="&#xe73d;" />
+                                Glyph="&#xe73d;"
+                                IsVisible="{Binding PingOkVisible}" />
 
-                            <Grid x:Name="PingError" x:FieldModifier="public">
+                            <Grid x:Name="PingError" IsVisible="{Binding PingErrorVisible}">
                                 <ui:FontIcon
                                     Margin="3"
                                     HorizontalAlignment="Right"

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Controls/NetworkCheck.axaml.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Controls/NetworkCheck.axaml.cs
@@ -1,14 +1,25 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-using Org.BouncyCastle.Asn1.Utilities;
 
 namespace BD.WTTS.UI.Views.Pages;
 
-public partial class NetworkCheck : UserControl
+public partial class NetworkCheck : UserControl, IViewFor<AcceleratorPageViewModel>
 {
     public NetworkCheck()
     {
         InitializeComponent();
+
+        Loaded += (_, _) =>
+        {
+            ViewModel = DataContext as AcceleratorPageViewModel;
+
+            this.OneWayBind(ViewModel, vm => vm.PingResultStatus, v => v.PingOK.IsVisible, result => result == AcceleratorPageViewModel.PingStatus.Ok);
+            this.OneWayBind(ViewModel, vm => vm.PingResultStatus, v => v.PingError.IsVisible, result => result == AcceleratorPageViewModel.PingStatus.Error);
+            this.OneWayBind(ViewModel, vm => vm.NATLevel, v => v.NATTextBlock.Text);
+            this.OneWayBind(ViewModel, vm => vm.NATTypeTip, v => v.NATTypeTip.Text);
+        };
     }
+
+    public AcceleratorPageViewModel? ViewModel { get; set; }
+
+    object? IViewFor.ViewModel { get; set; }
 }

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Controls/NetworkCheck.axaml.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Controls/NetworkCheck.axaml.cs
@@ -2,24 +2,10 @@ using Avalonia.Controls;
 
 namespace BD.WTTS.UI.Views.Pages;
 
-public partial class NetworkCheck : UserControl, IViewFor<AcceleratorPageViewModel>
+public partial class NetworkCheck : UserControl
 {
     public NetworkCheck()
     {
         InitializeComponent();
-
-        Loaded += (_, _) =>
-        {
-            ViewModel = DataContext as AcceleratorPageViewModel;
-
-            this.OneWayBind(ViewModel, vm => vm.PingResultStatus, v => v.PingOK.IsVisible, result => result == AcceleratorPageViewModel.PingStatus.Ok);
-            this.OneWayBind(ViewModel, vm => vm.PingResultStatus, v => v.PingError.IsVisible, result => result == AcceleratorPageViewModel.PingStatus.Error);
-            this.OneWayBind(ViewModel, vm => vm.NATLevel, v => v.NATTextBlock.Text);
-            this.OneWayBind(ViewModel, vm => vm.NATTypeTip, v => v.NATTypeTip.Text);
-        };
     }
-
-    public AcceleratorPageViewModel? ViewModel { get; set; }
-
-    object? IViewFor.ViewModel { get; set; }
 }

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Pages/AcceleratorPage2.axaml
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Pages/AcceleratorPage2.axaml
@@ -648,7 +648,7 @@
             </Panel>
 
             <!--  网络检测  -->
-            <spp:NetworkCheck x:Name="NetworkCheckControl" />
+            <spp:NetworkCheck DataContext="{Binding NetworkCheckControlViewModel}" />
 
             <TabItem Content="dummy_tab_for_transisit_animation" />
         </Carousel>

--- a/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Pages/AcceleratorPage2.axaml.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/UI/Views/Pages/AcceleratorPage2.axaml.cs
@@ -73,31 +73,6 @@ public partial class AcceleratorPage2 : PageBase<AcceleratorPageViewModel>
                 GameAccTab.IsVisible = false;
                 AcceleratorTabs.SelectedIndex = 0;
             }
-
-            NetworkCheckControl.PingOK.IsVisible = false;
-            NetworkCheckControl.PingError.IsVisible = false;
-            NetworkCheckControl.NATCheckButton.Click += (_, _) => NetworkCheckControl.PingError.IsVisible = NetworkCheckControl.PingOK.IsVisible = false;
-            ViewModel!.NATCheckCommand
-                .Subscribe(result =>
-                {
-                    (NetworkCheckControl.NATTextBlock.Text, NetworkCheckControl.NATTypeTip.Text) = result.Nat switch
-                    {
-                        AcceleratorPageViewModel.NatTypeSimple.Open => ("开放 NAT", "您可与在其网络上具有任意 NAT 类型的用户玩多人游戏和发起多人游戏。"),
-                        AcceleratorPageViewModel.NatTypeSimple.Moderate => ("中等 NAT", "您可与一些用户玩多人游戏；但是，并且通常你将不会被选为比赛的主持人。"),
-                        AcceleratorPageViewModel.NatTypeSimple.Strict => ("严格 NAT", "您只能与具有开放 NAT 类型的用户玩多人游戏。您不能被选为比赛的主持人。"),
-                        _ => ("不可用 NAT", "如果 NAT 不可用，您将无法使用群聊天或连接到某些 Xbox 游戏的多人游戏。"),
-                    };
-
-                    if (result.PingSuccess)
-                    {
-                        NetworkCheckControl.PingOK.IsVisible = true;
-                    }
-                    else
-                    {
-                        NetworkCheckControl.PingError.IsVisible = true;
-                    }
-                }).DisposeWith(disposables);
-            ViewModel.IPv6CheckCommand.Execute().Subscribe();
         });
 
         SearchGameBox.DropDownClosed += SearchGameBox_DropDownClosed;


### PR DESCRIPTION
这个PR干了什么：
将 NetworkCheck 业务从 `AcceleratorPageViewModel` 中分离出来，单独成为一个 ViewModel

危险度：较低，业务逻辑没有任何改变，页面行为表现无不同。
影响范围：低，只与 网络测试页面 有关联。

可能的注意点：新的ViewModel的配置方式。
```
AcceleratorPage2.axaml
<spp:NetworkCheck DataContext="{Binding NetworkCheckControlViewModel}" />

AcceleratorPageViewModel.cs
public NetworkCheckControlViewModel NetworkCheckControlViewModel { get; } = new();
``` 