### PR TITLE
🐛 修复证书过期后加速失效的问题

### DIFF
--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services/Certificate/ICertificateManager.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services/Certificate/ICertificateManager.cs
@@ -196,6 +196,11 @@ public interface ICertificateManager
                 // 生成证书
                 certificateManager.GenerateCertificate();
 
+                packable = GetRootCertificatePackable();
+                certificate2 = packable;
+                if (certificate2 == null)
+                    return StartProxyResultCode.GetX509Certificate2Fail;
+
                 // 安装证书
                 ICertificateManager.Constants.TrustRootCertificate(
                     GetCerFilePath, platformService, certificate2);


### PR DESCRIPTION
原本的行为 (windows)

1. 本地的证书过期后，点击启动加速会启动成功，即使本地证书已被更新，但是测试会显示error，访问被加速的页面全部无法访问。此时重新启动程序，启动加速后，测试加速页面正常。

2. （TODO）加速状态下，系统时间跨越证书到期时间，可以正常解析的加速页面全部无法访问了。