### PR TITLE
🐛 修复证书过期后加速失效的问题

### DIFF
--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/Certificate/CertificateManagerImpl.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/Certificate/CertificateManagerImpl.cs
@@ -129,7 +129,7 @@ sealed partial class CertificateManagerImpl : ICertificateManager
 
     bool SharedCreateRootCertificate()
     {
-        RootCertificate ??= LoadRootCertificate();
+        RootCertificate = LoadRootCertificate();
 
         if (RootCertificate != null)
         {

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/HttpServer/Certificates/CertService.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/HttpServer/Certificates/CertService.cs
@@ -83,7 +83,7 @@ sealed class CertService
             entry.SetAbsoluteExpiration(notAfter);
 
             var subjectName = new X500DistinguishedName($"CN={domain}");
-            using var serverCert = CertGenerator.CreateEndCertificate(caCert, subjectName, GetDomains(), notBefore, notAfter);
+            using var serverCert = CertGenerator.CreateEndCertificate(caCert, subjectName, GetDomains());
             var serverCertPfx = serverCert.Export(X509ContentType.Pfx);
             // 将生成的证书导出后重新创建一个
             return new X509Certificate2(serverCertPfx);

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.cs
@@ -47,8 +47,40 @@ sealed partial class YarpReverseProxyServiceImpl : ReverseProxyServiceImpl, IRev
             ICertificateManager.Constants.CheckRootCertificate(
                 platformService,
                 CertificateManager);
+
+            X509Certificate2? cer = CertificateManager.RootCertificatePackable;
+            if (cer is not null && DateTime.Now <= cer.NotAfter && cer.NotAfter <= DateTime.Now.AddMonths(1))
+            {
+                var interval = cer.NotAfter - DateTime.Now;
+
+                void StopCertificateTimer()
+                {
+                    _certificateTimer?.Stop();
+                    _certificateTimer?.Dispose();
+                    _certificateTimer = null;
+                }
+                StopCertificateTimer();
+
+                _certificateTimer = new System.Timers.Timer(interval)
+                {
+                    AutoReset = false,
+                };
+
+                _certificateTimer.Elapsed += async (_, _) =>
+                {
+                    ICertificateManager.Constants.CheckRootCertificate(
+                        platformService,
+                        CertificateManager);
+
+                    await StopProxyAsync();
+                    await StartProxyImpl();
+                };
+                _certificateTimer.Start();
+            }
         }
     }
+
+    private System.Timers.Timer? _certificateTimer;
 
     protected override Task<StartProxyResult> StartProxyImpl() => Task.FromResult(StartProxyCore());
 

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.cs
@@ -53,14 +53,6 @@ sealed partial class YarpReverseProxyServiceImpl : ReverseProxyServiceImpl, IRev
             {
                 var interval = cer.NotAfter - DateTime.Now;
 
-                void StopCertificateTimer()
-                {
-                    _certificateTimer?.Stop();
-                    _certificateTimer?.Dispose();
-                    _certificateTimer = null;
-                }
-                StopCertificateTimer();
-
                 _certificateTimer = new System.Timers.Timer(interval)
                 {
                     AutoReset = false,
@@ -81,6 +73,13 @@ sealed partial class YarpReverseProxyServiceImpl : ReverseProxyServiceImpl, IRev
     }
 
     private System.Timers.Timer? _certificateTimer;
+
+    private void StopCertificateTimer()
+    {
+        _certificateTimer?.Stop();
+        _certificateTimer?.Dispose();
+        _certificateTimer = null;
+    }
 
     protected override Task<StartProxyResult> StartProxyImpl() => Task.FromResult(StartProxyCore());
 
@@ -185,6 +184,7 @@ sealed partial class YarpReverseProxyServiceImpl : ReverseProxyServiceImpl, IRev
 
     public async Task StopProxyAsync()
     {
+        StopCertificateTimer();
         Scripts = null;
         if (app == null) return;
         await app.StopAsync();

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services/Certificate/ICertificateManager.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services/Certificate/ICertificateManager.cs
@@ -196,6 +196,11 @@ public interface ICertificateManager
                 // 生成证书
                 certificateManager.GenerateCertificate();
 
+                packable = GetRootCertificatePackable();
+                certificate2 = packable;
+                if (certificate2 == null)
+                    return StartProxyResultCode.GetX509Certificate2Fail;
+
                 // 安装证书
                 ICertificateManager.Constants.TrustRootCertificate(
                     GetCerFilePath, platformService, certificate2);


### PR DESCRIPTION
原本的行为 (windows)

(测试请先确保关闭其他系统代理)
1. 本地的证书过期后，点击启动加速会启动成功，但是测试会显示error，访问被加速的页面全部无法访问。此时停止加速，重新启动加速后，测试加速页面恢复正常。
2. 如果程序已经第一次加速过了，在程序运行期间，证书过期，那么无论重新加速多少次永远会失效，此时必须重新启动主程序。
3. 加速状态下，系统时间跨越证书到期时间，可以正常解析的加速页面全部无法访问了。

修正后，无论本地硬盘证书过期还是证书凌晨跨天执行，皆可以正常解析页面。