### PR TITLE
为桌面快捷方式添加启动窗口类

### DIFF
--- a/build/linux/init_desktop.sh
+++ b/build/linux/init_desktop.sh
@@ -11,6 +11,7 @@ Exec=$base_path/$exec_name.sh
 Icon=$base_path/Icons/Watt-Toolkit.png
 Terminal=false
 Type=Application
+StartupWMClass=Steam++
 StartupNotify=false" >"$HOME/Desktop/Watt Toolkit.desktop"
 chmod +x "$HOME/Desktop/Watt Toolkit.desktop"
 exit 0

--- a/build/linux/offline_init.sh
+++ b/build/linux/offline_init.sh
@@ -197,6 +197,7 @@ Exec=$base_path/$exec_name.sh
 Icon=$base_path/Icons/Watt-Toolkit.png
 Terminal=false
 Type=Application
+StartupWMClass=Steam++
 StartupNotify=false" >"$target_dir/Watt Toolkit.desktop"
     chmod +x "$target_dir/Watt Toolkit.desktop"
 

--- a/build/linux/online_install.sh
+++ b/build/linux/online_install.sh
@@ -437,6 +437,7 @@ Icon=$base_path/Icons/Watt-Toolkit.png
 Terminal=false
 Type=Application
 StartupNotify=false
+StartupWMClass=Steam++
 EOT
     chmod +x "$target_dir/Watt Toolkit.desktop"
 }


### PR DESCRIPTION
在 init_desktop.sh、offline_init.sh 和 online_install.sh 脚本中，为创建的"Watt Toolkit.desktop"文件添加了 
 StartupWMClass=Steam++ 行。这个修改将有助于窗口管理器正确识别和处理 Steam++ 应用窗口，解决在 linux 系统上dock栏图标问题。
![image](https://github.com/user-attachments/assets/9a844ff9-9acf-49e5-895e-039479087a49)
