### PR TITLE
Add quotes to prevent potential word splittings

### DIFF
--- a/build/linux/online_install.sh
+++ b/build/linux/online_install.sh
@@ -270,7 +270,7 @@ Get_NewVer() {
 
 Download_File() {
     # 删除旧的文件
-    rm -rf $tar_path
+    rm -rf "$tar_path"
     title="安装"
     # 检查 o_sha384 是否为空
     if [ -z "$o_sha384" ]; then

--- a/build/linux/uninstall.sh
+++ b/build/linux/uninstall.sh
@@ -85,15 +85,15 @@ zenity --question --text="是否删除用户数据?" --width=400
 delUserData=$?
 
 if [ $delUserData -eq 0 ]; then
-    rm -rf $AppData 2>/dev/null
-    rm -rf $AppData_t 2>/dev/null
+    rm -rf "$AppData" 2>/dev/null
+    rm -rf "$AppData_t" 2>/dev/null
     certutil -D -d $HOME/.pki/nssdb -n "SteamTools"
 else
     echo "保留用户数据方便下次安装。"
     echo "如需删除可手动删除该目录:$AppData 或者 $AppData_t"
 fi
-rm -rf $Cache 2>/dev/null
-rm -rf $Cache_t 2>/dev/null
-rm -rf $base_path 2>/dev/null
+rm -rf "$Cache" 2>/dev/null
+rm -rf "$Cache_t" 2>/dev/null
+rm -rf "$base_path" 2>/dev/null
 rm -rf "$HOME/Desktop/Watt Toolkit.desktop" 2>/dev/null
 zenity --info --text="卸载完成!" --width=300


### PR DESCRIPTION
As the title suggests, this PR includes the commit that adds quotes to several commands in `build/linux/online_install.sh` and `build/linux/uninstall.sh` to prevent potential word splittings (related to <https://www.shellcheck.net/wiki/SC2086>). For instance, `rm -rf $tar_path` is risky because `tar_path` is derived from `base_path`, which in turn comes from user input via `zenity`. If the user enters a path containing spaces, the unquoted variable could be split into multiple arguments, causing the command to behave unexpectedly.

如下为翻译：正如标题所示，本次PR包含在`build/linux/online_install.sh`和`build/linux/uninstall.sh`中为多个命令添加引号的提交，以防止潜在的单词分割问题（与<https://www.shellcheck.net/wiki/SC2086>相关）。例如，`rm -rf $tar_path` 存在风险，因为 `tar_path` 由 `base_path` 派生而来，而后者又来自用户通过 `zenity` 输入的路径。若用户输入的路径包含空格，未加引号的变量可能被拆分为多个参数，导致命令行为异常。