### PR TITLE
[codex] Add macOS native menu shortcuts

### DIFF
--- a/src/BD.WTTS.Client.Avalonia/UI/App.axaml.cs
+++ b/src/BD.WTTS.Client.Avalonia/UI/App.axaml.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Dom;
+using Avalonia.Input;
 using BD.WTTS.Client.Resources;
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
@@ -17,13 +18,93 @@ public sealed partial class App : Application
         OpenBrowserCommand = ReactiveCommand.Create<object?>(OpenBrowserCommandCore);
         CopyToClipboardCommand = ReactiveCommand.Create<object?>(CopyToClipboardCommandCore);
 #if MACOS
-        var menus = new NativeMenu();
-        menus.Add(new NativeMenuItem { Header = Strings.Settings, Command = ReactiveCommand.Create(() => { INavigationService.Instance.Navigate(typeof(SettingsPage)); }) });
-        menus.Add(new NativeMenuItemSeparator());
-        menus.Add(new NativeMenuItem { Header = Strings.Exit, Command = ReactiveCommand.Create(() => { Shutdown(); }) });
-        NativeMenu.SetMenu(this, menus);
+        InitializeMacOSNativeMenu();
 #endif
     }
+
+#if MACOS
+    void InitializeMacOSNativeMenu()
+    {
+        var appMenu = new NativeMenu();
+        appMenu.Add(new NativeMenuItem
+        {
+            Header = Strings.Settings,
+            Command = ReactiveCommand.Create(() => INavigationService.Instance.Navigate(typeof(SettingsPage))),
+        });
+        appMenu.Add(new NativeMenuItemSeparator());
+        appMenu.Add(new NativeMenuItem
+        {
+            Header = string.Format(GetMacMenuString("HideApp_", "Hide {0}"), Name),
+            Gesture = KeyGesture.Parse("CMD+H"),
+            Command = ReactiveCommand.Create(HideAllWindows),
+        });
+        appMenu.Add(new NativeMenuItem
+        {
+            Header = Strings.Exit,
+            Gesture = KeyGesture.Parse("CMD+Q"),
+            Command = ReactiveCommand.Create(() => Shutdown()),
+        });
+
+        var windowMenu = new NativeMenu();
+        windowMenu.Add(new NativeMenuItem
+        {
+            Header = GetMacMenuString("HideWindow", "Hide Window"),
+            Gesture = KeyGesture.Parse("CMD+W"),
+            Command = ReactiveCommand.Create(HideActiveWindow),
+        });
+
+        var menus = new NativeMenu();
+        menus.Add(new NativeMenuItem
+        {
+            Header = Name,
+            Menu = appMenu,
+        });
+        menus.Add(new NativeMenuItem
+        {
+            Header = GetMacMenuString("WindowMenu", "Window"),
+            Menu = windowMenu,
+        });
+
+        NativeMenu.SetMenu(this, menus);
+    }
+
+    static string GetMacMenuString(string key, string fallback)
+        => Strings.ResourceManager.GetString(key, Strings.Culture) ?? fallback;
+
+    void HideAllWindows()
+    {
+        MainThread2.BeginInvokeOnMainThread(() =>
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                foreach (var window in desktop.Windows.Where(x => x.IsVisible))
+                {
+                    window.Hide();
+                }
+                return;
+            }
+
+            MainWindow?.Hide();
+        });
+    }
+
+    void HideActiveWindow()
+    {
+        MainThread2.BeginInvokeOnMainThread(() =>
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                var window = desktop.Windows.FirstOrDefault(x => x.IsActive) ??
+                             MainWindow ??
+                             desktop.Windows.FirstOrDefault();
+                window?.Hide();
+                return;
+            }
+
+            MainWindow?.Hide();
+        });
+    }
+#endif
 
     /// <summary>
     /// 获取当前主窗口

--- a/src/BD.WTTS.Client/Resources/Strings.en.resx
+++ b/src/BD.WTTS.Client/Resources/Strings.en.resx
@@ -3140,6 +3140,12 @@ The system will {1} after {0} seconds.</value>
     <value>Close</value>
     <comment>Author=kotovasia5120</comment>
   </data>
+  <data name="HideApp_" xml:space="preserve">
+    <value>Hide {0}</value>
+  </data>
+  <data name="HideWindow" xml:space="preserve">
+    <value>Hide Window</value>
+  </data>
   <data name="Minimize" xml:space="preserve">
     <value>Minimize</value>
     <comment>Author=kotovasia5120</comment>
@@ -3155,6 +3161,9 @@ The system will {1} after {0} seconds.</value>
   <data name="Back" xml:space="preserve">
     <value>Back</value>
     <comment>Author=kotovasia5120</comment>
+  </data>
+  <data name="WindowMenu" xml:space="preserve">
+    <value>Window</value>
   </data>
   <data name="LoginVerify" xml:space="preserve">
     <value>LoginVerify</value>

--- a/src/BD.WTTS.Client/Resources/Strings.resx
+++ b/src/BD.WTTS.Client/Resources/Strings.resx
@@ -299,6 +299,12 @@
 	<data name="Close" xml:space="preserve">
     <value>关闭</value>
   </data>
+	<data name="HideApp_" xml:space="preserve">
+    <value>隐藏 {0}</value>
+  </data>
+	<data name="HideWindow" xml:space="preserve">
+    <value>隐藏窗口</value>
+  </data>
 	<data name="Minimize" xml:space="preserve">
     <value>最小化</value>
   </data>
@@ -310,6 +316,9 @@
   </data>
 	<data name="Back" xml:space="preserve">
     <value>返回</value>
+  </data>
+	<data name="WindowMenu" xml:space="preserve">
+    <value>窗口</value>
   </data>
 	<data name="Confirm" xml:space="preserve">
     <value>确定</value>


### PR DESCRIPTION
## What changed

- added a macOS native application menu with `Cmd+H` mapped to hide the app windows
- added a macOS window menu entry with `Cmd+W` mapped to hide the active window
- kept `Cmd+Q` as an explicit application quit action
- added localized menu strings for the new macOS menu entries

## Why

The macOS build only registered a minimal native menu, so standard macOS shortcuts like `Cmd+H`, `Cmd+W`, and `Cmd+Q` were not fully wired into the application lifecycle.

## Impact

macOS users now get the expected shortcut behavior:

- `Cmd+H` hides the app windows
- `Cmd+W` hides the current window instead of acting like quit
- `Cmd+Q` still exits the app

## Root cause

The app-level `NativeMenu` only exposed Settings and Exit, and the main window behavior relied on close interception rather than native macOS menu shortcut bindings.

## Validation

- inspected the macOS Avalonia menu and window lifecycle code paths
- ran `git diff --check`
- attempted `dotnet build src/BD.WTTS.Client.Avalonia.App/BD.WTTS.Client.Avalonia.App.csproj`, but `dotnet` is not installed in this environment
