### PR TITLE
🔨 修复加速后 Git for Windows SDK 无法访问 GitHub：本地提供 CRL 并为 MITM 证书添加吊销分发点

### DIFF
--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Extensions/KestrelServerOptionsExtensions.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Extensions/KestrelServerOptionsExtensions.cs
@@ -33,21 +33,23 @@ public static class KestrelServerOptionsExtensions
                 $"TCP port {httpProxyPort} is already occupied by other processes.");
         }
 
-        options.Listen(IReverseProxyService.Constants.Instance.ProxyIp, httpProxyPort, listen =>
-        {
-            listen.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
-            var proxyMiddleware = options.ApplicationServices.GetRequiredService<HttpProxyMiddleware>();
-            var tunnelMiddleware = options.ApplicationServices.GetRequiredService<TunnelMiddleware>();
+        var proxyMiddleware = options.ApplicationServices.GetRequiredService<HttpProxyMiddleware>();
+        var tunnelMiddleware = options.ApplicationServices.GetRequiredService<TunnelMiddleware>();
 
-            listen.UseFlowAnalyze();
-            listen.Use(next => context => proxyMiddleware.InvokeAsync(next, context));
-            listen.UseTls();
-            listen.Use(next => context => tunnelMiddleware.InvokeAsync(next, context));
-        });
-
-        options.GetLogger().LogInformation(
+        options.ListenAndLog(
+            IReverseProxyService.Constants.Instance.ProxyIp,
+            httpProxyPort,
+            listen =>
+            {
+                listen.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
+                listen.UseFlowAnalyze();
+                listen.Use(next => context => proxyMiddleware.InvokeAsync(next, context));
+                listen.UseTls();
+                listen.Use(next => context => tunnelMiddleware.InvokeAsync(next, context));
+            },
             "Listened http://{ProxyIp}:{httpProxyPort}, HTTP proxy service startup completed.",
-            IReverseProxyService.Constants.Instance.ProxyIp, httpProxyPort);
+            IReverseProxyService.Constants.Instance.ProxyIp,
+            httpProxyPort);
     }
 
 #if WINDOWS
@@ -59,15 +61,10 @@ public static class KestrelServerOptionsExtensions
     public static void ListenSshReverseProxy(this KestrelServerOptions options)
     {
         var sshPort = IReverseProxyConfig.SshPort;
-        options.ListenLocalhost(sshPort, listen =>
-        {
-            listen.UseFlowAnalyze();
-            listen.UseConnectionHandler<GithubSshReverseProxyHandler>();
-        });
-
-        var logger = options.GetLogger();
-        logger.LogInformation(
-            "Listened ssh://localhost:{sshPort}, the SSH reverse proxy service of GitHub is started.", sshPort);
+        options.ListenLocalReverseProxy<GithubSshReverseProxyHandler>(
+            sshPort,
+            "Listened ssh://localhost:{sshPort}, the SSH reverse proxy service of GitHub is started.",
+            sshPort);
     }
 #endif
 
@@ -80,15 +77,10 @@ public static class KestrelServerOptionsExtensions
     public static void ListenGitReverseProxy(this KestrelServerOptions options)
     {
         var gitPort = IReverseProxyConfig.GitPort;
-        options.ListenLocalhost(gitPort, listen =>
-        {
-            listen.UseFlowAnalyze();
-            listen.UseConnectionHandler<GithubGitReverseProxyHandler>();
-        });
-
-        var logger = options.GetLogger();
-        logger.LogInformation(
-            "Listened git://localhost:{gitPort}, the Git reverse proxy service of GitHub has been started.", gitPort);
+        options.ListenLocalReverseProxy<GithubGitReverseProxyHandler>(
+            gitPort,
+            "Listened git://localhost:{gitPort}, the Git reverse proxy service of GitHub has been started.",
+            gitPort);
     }
 #endif
 
@@ -100,12 +92,29 @@ public static class KestrelServerOptionsExtensions
     public static void ListenHttpReverseProxy(this KestrelServerOptions options)
     {
         var httpPort = IReverseProxyConfig.HttpPort;
-        options.Listen(IReverseProxyService.Constants.Instance.ProxyIp, httpPort);
-
-        var logger = options.GetLogger();
-        logger.LogInformation(
+        options.ListenAndLog(
+            IReverseProxyService.Constants.Instance.ProxyIp,
+            httpPort,
+            static _ => { },
             "Listened http://{ProxyIp}:{httpPort}, HTTP reverse proxy service startup completed.",
-            IReverseProxyService.Constants.Instance.ProxyIp, httpPort);
+            IReverseProxyService.Constants.Instance.ProxyIp,
+            httpPort);
+    }
+
+    /// <summary>
+    /// 监听 CRL（证书吊销列表）服务，供 Schannel 等客户端完成本地 MITM 证书的吊销检查
+    /// </summary>
+    /// <param name="options"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ListenCrlReverseProxy(this KestrelServerOptions options)
+    {
+        var crlPort = IReverseProxyConfig.CrlPort;
+        options.ListenAndLog(
+            IPAddress.Loopback,
+            crlPort,
+            static listen => listen.Protocols = HttpProtocols.Http1,
+            "Listened http://127.0.0.1:{crlPort}, CRL service startup completed.",
+            crlPort);
     }
 
     /// <summary>
@@ -122,17 +131,44 @@ public static class KestrelServerOptionsExtensions
         domainResolver.CheckIpv6SupportAsync();
 
         var httpsPort = IReverseProxyConfig.HttpsPort;
-        options.Listen(IReverseProxyService.Constants.Instance.ProxyIp, httpsPort, listen =>
+        options.ListenAndLog(
+            IReverseProxyService.Constants.Instance.ProxyIp,
+            httpsPort,
+            static listen =>
+            {
+                listen.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
+                listen.UseFlowAnalyze();
+                listen.UseTls();
+            },
+            "Listened https://{ProxyIp}:{httpsPort}, HTTPS reverse proxy service startup completed.",
+            IReverseProxyService.Constants.Instance.ProxyIp,
+            httpsPort);
+    }
+
+    /// <summary>
+    /// 监听本地反向代理（SSH / Git 通用）
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void ListenLocalReverseProxy<TConnectionHandler>(this KestrelServerOptions options, int port, string message, params object[] args)
+        where TConnectionHandler : ConnectionHandler
+    {
+        options.ListenLocalhost(port, listen =>
         {
-            listen.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
             listen.UseFlowAnalyze();
-            listen.UseTls();
+            listen.UseConnectionHandler<TConnectionHandler>();
         });
 
-        var logger = options.GetLogger();
-        logger.LogInformation(
-            "Listened https://{ProxyIp}:{httpsPort}, HTTPS reverse proxy service startup completed.",
-            IReverseProxyService.Constants.Instance.ProxyIp, httpsPort);
+        options.GetLogger().LogInformation(message, args);
+    }
+
+    /// <summary>
+    /// 监听指定地址并记录启动日志
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void ListenAndLog(this KestrelServerOptions options, IPAddress ip, int port, Action<ListenOptions> configure, string message, params object[] args)
+    {
+        options.Listen(ip, port, configure);
+        options.GetLogger().LogInformation(message, args);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Extensions/ServiceCollectionExtensions.cs
@@ -114,6 +114,7 @@ public static partial class ServiceCollectionExtensions
             .AddMemoryCache()
             .AddHttpForwarder()
             .AddSingleton<CertService>()
+            .AddSingleton<CrlMiddleware>()
             //.AddSingleton<ICaCertInstaller, CaCertInstallerOfMacOS>()
             //.AddSingleton<ICaCertInstaller, CaCertInstallerOfWindows>()
             //.AddSingleton<ICaCertInstaller, CaCertInstallerOfLinuxRedHat>()

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Models/Abstractions/IReverseProxyConfig.GlobalListener.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Models/Abstractions/IReverseProxyConfig.GlobalListener.cs
@@ -39,6 +39,13 @@ partial interface IReverseProxyConfig
     /// </summary>
     static int HttpsPort { get; } = GetAvailableTcpPort(HttpsPortDefault);
 
+    const int CrlPortDefault = 26502;
+
+    /// <summary>
+    /// CRL（证书吊销列表）服务端口，用于为本地 MITM 证书提供吊销分发点
+    /// </summary>
+    static int CrlPort { get; } = GetAvailableTcpPort(CrlPortDefault);
+
     /// <summary>
     /// 获取已监听的端口
     /// </summary>

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/Certificate/CertGenerator.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/Certificate/CertGenerator.cs
@@ -1,5 +1,6 @@
 // https://github.com/dotnetcore/FastGithub/blob/2.1.4/FastGithub.HttpServer/CertGenerator.cs
 
+using System.Formats.Asn1;
 using X509Certificate2 = System.Security.Cryptography.X509Certificates.X509Certificate2;
 
 // ReSharper disable once CheckNamespace
@@ -97,7 +98,8 @@ public static class CertGenerator
         IEnumerable<string>? extraDnsNames = default,
         DateTimeOffset? notBefore = default,
         DateTimeOffset? notAfter = default,
-        int rsaKeySizeInBits = 2048)
+        int rsaKeySizeInBits = 2048,
+        string? crlDistributionPointUrl = default)
     {
         using var rsa = RSA.Create(rsaKeySizeInBits);
         var request = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
@@ -132,6 +134,11 @@ public static class CertGenerator
         var dnsNames = dnsBuilder.Build();
         request.CertificateExtensions.Add(dnsNames);
 
+        if (!string.IsNullOrEmpty(crlDistributionPointUrl))
+        {
+            request.CertificateExtensions.Add(CreateCrlDistributionPointExtension(crlDistributionPointUrl));
+        }
+
         if (notBefore == null || notBefore.Value < issuerCertificate.NotBefore)
         {
             notBefore = issuerCertificate.NotBefore;
@@ -145,6 +152,39 @@ public static class CertGenerator
         var serialNumber = BitConverter.GetBytes(Random.Shared.NextInt64());
         using var certOnly = request.Create(issuerCertificate, notBefore.Value, notAfter.Value, serialNumber);
         return certOnly.CopyWithPrivateKey(rsa);
+    }
+
+    /// <summary>
+    /// 创建 CRL 分发点扩展（OID 2.5.29.31），使 Schannel 等客户端可获取本地 CRL 完成吊销检查
+    /// </summary>
+    /// <param name="crlUrl">CRL 的 HTTP 地址</param>
+    /// <returns></returns>
+    static X509Extension CreateCrlDistributionPointExtension(string crlUrl)
+    {
+        // CRLDistributionPoints ::= SEQUENCE OF DistributionPoint
+        // DistributionPoint ::= SEQUENCE {
+        //   distributionPoint [0] DistributionPointName OPTIONAL,
+        //   ... }
+        // DistributionPointName ::= CHOICE { fullName [0] GeneralNames }
+        // GeneralName ::= CHOICE { uniformResourceIdentifier [6] IA5String }
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        using (writer.PushSequence()) // CRLDistributionPoints
+        {
+            using (writer.PushSequence()) // DistributionPoint
+            {
+                using (writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 0))) // distributionPoint [0]
+                {
+                    using (writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 0))) // fullName [0]
+                    {
+                        writer.WriteCharacterString(
+                            UniversalTagNumber.IA5String,
+                            crlUrl,
+                            new Asn1Tag(TagClass.ContextSpecific, 6)); // uniformResourceIdentifier
+                    }
+                }
+            }
+        }
+        return new X509Extension("2.5.29.31", writer.Encode(), critical: false);
     }
 
     private static void Add(this SubjectAlternativeNameBuilder builder, string name)

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/HttpServer/Certificates/CertService.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/HttpServer/Certificates/CertService.cs
@@ -14,6 +14,7 @@ sealed class CertService
     readonly ILogger<CertService> logger;
     readonly IReverseProxyConfig reverseProxyConfig;
     private X509Certificate2? caCert;
+    readonly Lazy<byte[]?> crlBytes;
 
     ReverseProxyServiceImpl ReverseProxyService => reverseProxyConfig.Service;
 
@@ -35,6 +36,29 @@ sealed class CertService
         this.serverCertCache = serverCertCache;
         this.logger = logger;
         this.reverseProxyConfig = reverseProxyConfig;
+
+        // 惰性初始化空 CRL（线程安全），避免对外暴露锁字段
+        crlBytes = new Lazy<byte[]?>(
+            () =>
+            {
+                try
+                {
+                    caCert ??= new X509Certificate2(fileName: CaPfxFilePath, password: default(string));
+
+                    return new CertificateRevocationListBuilder().Build(
+                        caCert,
+                        System.Numerics.BigInteger.One,
+                        DateTimeOffset.Now.AddDays(30),
+                        HashAlgorithmName.SHA256,
+                        RSASignaturePadding.Pkcs1);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "CreateEmptyCrl Error");
+                    return null;
+                }
+            },
+            LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     /// <summary>
@@ -63,6 +87,11 @@ sealed class CertService
     }
 
     /// <summary>
+    /// 获取由根 CA 签名的空 CRL 字节，供本地 HTTP 服务对外提供，以完成 Schannel 的吊销检查
+    /// </summary>
+    public byte[]? CrlBytes => crlBytes.Value;
+
+    /// <summary>
     /// 获取颁发给指定域名的证书
     /// </summary>
     /// <param name="domain"></param> 
@@ -83,7 +112,10 @@ sealed class CertService
             entry.SetAbsoluteExpiration(notAfter);
 
             var subjectName = new X500DistinguishedName($"CN={domain}");
-            using var serverCert = CertGenerator.CreateEndCertificate(caCert, subjectName, GetDomains());
+            // 本地 CRL 服务的 HTTP 地址（写入 MITM 叶子证书的 CRL 分发点）
+            using var serverCert = CertGenerator.CreateEndCertificate(
+                caCert, subjectName, GetDomains(),
+                crlDistributionPointUrl: CrlBytes == null ? null : $"http://{IPAddress.Loopback}:{IReverseProxyConfig.CrlPort}/crl");
             var serverCertPfx = serverCert.Export(X509ContentType.Pfx);
             // 将生成的证书导出后重新创建一个
             return new X509Certificate2(serverCertPfx);

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/HttpServer/Middleware/CrlMiddleware.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/HttpServer/Middleware/CrlMiddleware.cs
@@ -1,0 +1,41 @@
+// ReSharper disable once CheckNamespace
+namespace BD.WTTS.Services.Implementation;
+
+/// <summary>
+/// CRL（证书吊销列表）服务中间件，用于对外提供本地 MITM 证书的吊销分发点
+/// </summary>
+sealed class CrlMiddleware
+{
+    readonly CertService certService;
+
+    public CrlMiddleware(CertService certService)
+    {
+        this.certService = certService;
+    }
+
+    /// <summary>
+    /// 处理请求
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="next"></param>
+    /// <returns></returns>
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        if (HttpMethods.IsGet(context.Request.Method) &&
+            context.Request.Path.Equals(new PathString("/crl"), StringComparison.OrdinalIgnoreCase))
+        {
+            var crlBytes = certService.CrlBytes;
+            if (crlBytes == null)
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+            context.Response.ContentType = "application/pkix-crl";
+            await context.Response.Body.WriteAsync(crlBytes);
+        }
+        else
+        {
+            await next(context);
+        }
+    }
+}

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.Startup.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.Startup.cs
@@ -41,6 +41,10 @@ partial class YarpReverseProxyServiceImpl
     {
         app.UseHttpLocalRequest();
 
+        // 使用 CRL 证书吊销列表中间件
+        var crlMiddleware = app.ApplicationServices.GetRequiredService<CrlMiddleware>();
+        app.Use(next => context => crlMiddleware.InvokeAsync(context, next));
+
         app.UseHttpProxyPac();
         app.UseRequestLogging();
         app.UseHttpReverseProxy();

--- a/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator.ReverseProxy/Services.Implementation/YarpReverseProxyServiceImpl.cs
@@ -200,6 +200,7 @@ sealed partial class YarpReverseProxyServiceImpl : ReverseProxyServiceImpl, IRev
                 else
                 {
                     options.ListenHttpsReverseProxy();
+                    options.ListenCrlReverseProxy();
                     if (EnableHttpProxyToHttps)
                         options.ListenHttpReverseProxy();
                 }

--- a/src/BD.WTTS.Client.Plugins.Accelerator/Services/Mvvm/ProxyService.cs
+++ b/src/BD.WTTS.Client.Plugins.Accelerator/Services/Mvvm/ProxyService.cs
@@ -424,6 +424,9 @@ public sealed partial class ProxyService
     public async Task InitializeAccelerateAsync()
     {
         ProxyDomains.Clear();
+        // 先加载本地缓存，避免后端不可达时面板长时间空白
+        LoadOrSaveLocalAccelerate();
+
         // 加载代理服务数据
         var client = IMicroServiceClient.Instance.Accelerate;
 #if DEBUG
@@ -437,9 +440,9 @@ public sealed partial class ProxyService
         if (result.IsSuccess)
         {
             ProxyDomains.AddOrUpdate(result.Content!);
+            // 用最新数据更新本地缓存
+            LoadOrSaveLocalAccelerate();
         }
-
-        LoadOrSaveLocalAccelerate();
 
         if (ProxySettings.SupportProxyServicesStatus.Value.Any_Nullable() && ProxyDomains.Items.Any_Nullable())
         {

--- a/src/BD.WTTS.UnitTest/CertGeneratorCrlUnitTest.cs
+++ b/src/BD.WTTS.UnitTest/CertGeneratorCrlUnitTest.cs
@@ -1,0 +1,234 @@
+using System.Formats.Asn1;
+using System.Net;
+using System.Net.Sockets;
+
+namespace BD.WTTS.UnitTest;
+
+public sealed class CertGeneratorCrlUnitTest
+{
+    [Test]
+    public void EndCertificate_ContainsCrlDistributionPoint()
+    {
+        using var caCert = CreateTestCa();
+
+        const string crlUrl = "http://127.0.0.1:26502/crl";
+        using var endCert = CertGenerator.CreateEndCertificate(
+            caCert, new X500DistinguishedName("CN=github.com"), null, crlDistributionPointUrl: crlUrl);
+
+        var cdp = endCert.Extensions["2.5.29.31"];
+        Assert.That(cdp, Is.Not.Null, "叶子证书应包含 CRL 分发点扩展");
+
+        // 从 CRLDistributionPoints 扩展的 DER 中读取第一个 uniformResourceIdentifier 并断言
+        Assert.That(
+            new AsnReader(cdp!.RawData, AsnEncodingRules.DER)
+                .ReadSequence() // CRLDistributionPoints
+                .ReadSequence() // DistributionPoint
+                .ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0)) // distributionPoint [0]
+                .ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0)) // fullName [0]
+                .ReadCharacterString(
+                    UniversalTagNumber.IA5String,
+                    new Asn1Tag(TagClass.ContextSpecific, 6)), // uniformResourceIdentifier
+            Is.EqualTo(crlUrl));
+    }
+
+    [Test]
+    public void EmptyCrl_Issuer_IsCa()
+    {
+        using var caCert = CreateTestCa();
+
+        var crlBytes = BuildEmptyCrl(caCert);
+
+        Assert.That(crlBytes, Is.Not.Null);
+        Assert.That(crlBytes.Length, Is.GreaterThan(0));
+        Assert.That(ContainsSubsequence(crlBytes, caCert.SubjectName.RawData), Is.True,
+            "CRL 应包含根 CA 的 Issuer 名称");
+    }
+
+    [Test]
+    public void EndCertificate_ChainsToCa_WithNoRevocationCheck()
+    {
+        using var caCert = CreateTestCa();
+
+        using var endCert = CertGenerator.CreateEndCertificate(
+            caCert, new X500DistinguishedName("CN=github.com"), null,
+            crlDistributionPointUrl: "http://127.0.0.1:26502/crl");
+
+        using var chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+        chain.ChainPolicy.ExtraStore.Add(caCert);
+
+        Assert.That(chain.Build(endCert), Is.True,
+            $"叶子证书应能构建到 CA: {string.Join("; ", chain.ChainStatus.Select(s => s.StatusInformation))}");
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void CrlServer_ServesValidCrlOverHttp()
+    {
+        using var caCert = CreateTestCa();
+        var crlBytes = BuildEmptyCrl(caCert);
+
+        using var server = new LocalCrlServer(crlBytes);
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        Assert.That(http.GetByteArrayAsync(server.CrlUrl).GetAwaiter().GetResult(), Is.EqualTo(crlBytes),
+            "CDP 指向的 URL 应能返回完整 CRL 字节");
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void EndCertificate_OnlineRevocation_PassesWithLocalCrl()
+    {
+        // 模拟真实场景：根 CA 受信任 + 本地 HttpListener 提供 CRL。
+        // 根信任用 X509ChainPolicy.CustomTrustStore（临时信任库，不写系统证书库、不弹窗、无残留）。
+        using var caCert = CreateTestCa();
+        var crlBytes = BuildEmptyCrl(caCert);
+
+        using var server = new LocalCrlServer(crlBytes);
+
+        using var endCert = CertGenerator.CreateEndCertificate(
+            caCert, new X500DistinguishedName("CN=github.com"), null,
+            crlDistributionPointUrl: server.CrlUrl);
+
+        var chain = new X509Chain();
+        var chainDisposed = false;
+        try
+        {
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+            chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+            chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+            chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(10);
+            // 将测试根 CA 加入临时信任库，替代写系统 Root 存储（避免证书弹窗与残留）
+            chain.ChainPolicy.CustomTrustStore.Add(caCert);
+            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+
+            var buildTask = Task.Run(() => chain.Build(endCert));
+            if (!buildTask.Wait(TimeSpan.FromSeconds(30)))
+            {
+                // 超时保护：不释放 chain（后台线程可能仍在使用），避免访问冲突；仅报告失败
+                Assert.Fail("X509Chain.Build(Online) 超时（30s）：本地 CRL 未能在限定时间内完成吊销检查。");
+                return;
+            }
+            chainDisposed = true;
+            Assert.That(buildTask.Result, Is.True,
+                $"吊销检查失败: {string.Join("; ", chain.ChainStatus.Select(s => s.StatusInformation))}");
+        }
+        finally
+        {
+            if (chainDisposed)
+            {
+                chain.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// 构建由指定 CA 签名的空 CRL
+    /// </summary>
+    static byte[] BuildEmptyCrl(X509Certificate2 caCert)
+    {
+        return new CertificateRevocationListBuilder().Build(
+            caCert,
+            System.Numerics.BigInteger.One,
+            DateTimeOffset.UtcNow.AddDays(30),
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+    }
+
+    /// <summary>
+    /// 判断 haystack 中是否包含 needle 子序列
+    /// </summary>
+    static bool ContainsSubsequence(byte[] haystack, byte[] needle)
+    {
+        if (needle.Length == 0) return true;
+        for (int i = 0; i <= haystack.Length - needle.Length; i++)
+        {
+            var match = true;
+            for (int j = 0; j < needle.Length; j++)
+            {
+                if (haystack[i + j] != needle[j])
+                {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// 创建测试用根 CA 证书
+    /// </summary>
+    static X509Certificate2 CreateTestCa()
+    {
+        return CertGenerator.CreateCACertificate(
+            new X500DistinguishedName("CN=WattToolkitTestCA"),
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddYears(1));
+    }
+
+    /// <summary>
+    /// 获取一个空闲的本地端口（HttpListener 不支持端口 0 自动分配后回读）
+    /// </summary>
+    static int GetIdlePort()
+    {
+        using var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        int port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+        return port;
+    }
+
+    /// <summary>
+    /// 在本地通过 HTTP 托管指定的 CRL 字节，供在线吊销检查测试使用。
+    /// 端口自动分配以避免冲突；Dispose 时停止监听器。
+    /// </summary>
+    sealed class LocalCrlServer : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly byte[] _crlBytes;
+
+        public string CrlUrl { get; }
+
+        public LocalCrlServer(byte[] crlBytes)
+        {
+            _crlBytes = crlBytes;
+            int port = GetIdlePort();
+            CrlUrl = $"http://127.0.0.1:{port}/crl";
+            _listener = new HttpListener();
+            _listener.Prefixes.Add($"{CrlUrl}/");
+            _listener.Start();
+            _ = Task.Run(ServeLoop);
+        }
+
+        async Task ServeLoop()
+        {
+            while (_listener.IsListening)
+            {
+                HttpListenerContext? context;
+                try
+                {
+                    context = await _listener.GetContextAsync();
+                }
+                catch
+                {
+                    break; // 监听器已停止
+                }
+                var response = context.Response;
+                response.StatusCode = 200;
+                response.ContentType = "application/pkix-crl";
+                response.ContentLength64 = _crlBytes.Length;
+                await response.OutputStream.WriteAsync(_crlBytes);
+                response.Close();
+            }
+        }
+
+        public void Dispose()
+        {
+            _listener.Stop();
+            _listener.Close();
+        }
+    }
+}


### PR DESCRIPTION
## 修复内容

修复启用加速后 Git for Windows SDK 无法访问 GitHub 的问题（curl 报 CRYPT_E_NO_REVOCATION_CHECK 0x80092012 / curl: (35) ... schannel）。

### 根因

本地根 CA 签发的 MITM 叶子证书缺少 CRL 分发点（CDP）扩展。Schannel（Git for Windows SDK 使用的 TLS 后端）强制执行吊销检查，找不到吊销分发点即判定失败，导致 TLS 握手被拒绝。

### 改动

- 反代服务在本机新增一个 CRL 服务（`http://127.0.0.1:{CrlPort}/crl`），对外提供由本地根 CA 签名的空 CRL。
- 为 MITM 叶子证书添加 CRL 分发点扩展（OID 2.5.29.31），指向上述本地 CRL 服务。
- 新增单元测试覆盖：CDP 扩展、空 CRL 签发者、吊销检查回归、CRL 端点及 X509RevocationMode.Online 链构建。

### 验证

- 单元测试 5/5 通过。
- 真机验证：启用加速后 `curl -v https://github.com` 正常返回 HTTP 200 与完整页面；git ls-remote 正常拉取引用列表。

Fixes #4123